### PR TITLE
feat: Implement File-Size-Based LRU Cache and Introduce Configurable Parameters

### DIFF
--- a/server/src/cache.rs
+++ b/server/src/cache.rs
@@ -30,7 +30,7 @@ pub struct DiskCache {
     cache_dir: PathBuf,
     max_size: u64,
     current_size: u64,
-    access_order: VecDeque<String>,
+    access_order: VecDeque<(String, u64)>,
 }
 
 #[derive(rocket::Responder)]
@@ -87,10 +87,12 @@ impl DiskCache {
             match cache.get_s3_file_to_cache(&uid_str, connector).await {
                 Ok(local_file_name) => {
                     debug!("{} fetched from S3", &uid_str);
-                    cache.ensure_capacity(redis_read).await;
-                    let file_size = 1; // Assume each file has size 1 for simplicity
+                    let metadata = fs::metadata(&cache.cache_dir.join(&local_file_name)).ok();
+                    let file_size = metadata.unwrap().len();
+                    debug!("File size: {} bytes", file_size);
+                    cache.ensure_capacity(&redis_read, file_size).await;
                     cache.current_size += file_size;
-                    cache.access_order.push_back(uid_str.clone());
+                    cache.access_order.push_back((uid_str.clone(), file_size.clone()));
                     let _ = redis_read
                         .set_file_cache_loc(uid_str.clone(), local_file_name.clone())
                         .await;
@@ -122,42 +124,39 @@ impl DiskCache {
             .await
     }
 
-    async fn ensure_capacity(&mut self, redis_read: &RwLockReadGuard<'_, RedisServer>) {
-        // Trigger eviction if the cache is full or over its capacity
-        while self.current_size >= self.max_size && !self.access_order.is_empty() {
-            if let Some(evicted_file_name) = self.access_order.pop_front() {
+    async fn ensure_capacity(&mut self, redis_read: &RwLockReadGuard<'_, RedisServer>, new_file_size: u64) {
+        while self.current_size + new_file_size > self.max_size && !self.access_order.is_empty() {
+            if let Some((evicted_file_name, evicted_file_size)) = self.access_order.pop_front() {
                 let evicted_path = self.cache_dir.join(&evicted_file_name);
-                match fs::metadata(&evicted_path) {
-                    Ok(metadata) => {
-                        let _file_size = metadata.len();
-                        if let Ok(_) = fs::remove_file(&evicted_path) {
-                            // Ensure the cache size is reduced by the actual size of the evicted file
-                            self.current_size -= 1;
-                            let _ = redis_read.remove_file(evicted_file_name.clone()).await;
-
-                            info!("Evicted file: {}", evicted_file_name);
-                        } else {
-                            eprintln!("Failed to delete file: {}", evicted_path.display());
-                        }
-                    }
-                    Err(e) => eprintln!(
-                        "Failed to get metadata for file: {}. Error: {}",
-                        evicted_path.display(),
-                        e
-                    ),
+                if fs::remove_file(&evicted_path).is_ok() {
+                    self.current_size -= evicted_file_size;
+                    let _ = redis_read.remove_file(evicted_file_name.clone()).await;
+                    info!("Evicted file: {}", evicted_file_name);
+                } else {
+                        eprintln!("Failed to delete file: {}", evicted_path.display());
                 }
             }
         }
     }
     // Update a file's position in the access order
-    fn update_access(&mut self, file_name: &String) {
-        self.access_order.retain(|x| x != file_name);
-        self.access_order.push_back(file_name.clone());
+    fn update_access(&mut self, file_name: &str) {
+        let mut file_size: Option<u64> = None;
+        self.access_order.retain(|(name, size)| {
+            if name == file_name {
+                file_size = Some(*size);
+                false
+            } else {
+                true
+            }
+        });
+        if let Some(size) = file_size {
+            self.access_order.push_back((file_name.to_string(), size.clone()));
+        }
     }
 
     async fn empty(&mut self, redis_read: &RwLockReadGuard<'_, RedisServer>) {
         self.current_size = 0;
-        while let Some(x) = self.access_order.pop_front() {
+        while let Some((x, _)) = self.access_order.pop_front() {
             let evicted_path = self.cache_dir.join(&x);
             let _ = fs::remove_file(&evicted_path);
             let _ = redis_read.remove_file(x).await;
@@ -239,10 +238,12 @@ impl ConcurrentDiskCache {
         for (index, shard) in self.shards.iter().enumerate() {
             match tokio::time::timeout(std::time::Duration::from_secs(5), shard.lock()).await {
                 Ok(shard_guard) => {
-                    let files_in_shard: Vec<_> = shard_guard.access_order.iter().collect();
+                    let files_in_shard: Vec<_> = shard_guard.access_order.iter()
+                    .map(|(name, size)| format!("{} ({}B)", name, size))
+                    .collect::<Vec<String>>();
                     let total_files = files_in_shard.len();
-                    let used_capacity_pct =
-                        (shard_guard.current_size as f64 / shard_guard.max_size as f64) * 100.0;
+                    let calculated_current_size: u64 = shard_guard.access_order.iter().map(|(_, size)| size).sum();
+                    let used_capacity_pct = (calculated_current_size as f64 / shard_guard.max_size as f64) * 100.0;
                     stats_summary.push_str(&format!(
                         "{:<15} | {:<12} | {:<12.2} | {:<10} | {:?}\n",
                         format!("Shard {}", index),

--- a/server/src/cache.rs
+++ b/server/src/cache.rs
@@ -16,7 +16,6 @@ use crate::storage::storage_connector::StorageConnector;
 use crate::util::hash;
 
 // Constants
-const BUCKET_SIZE: u64 = 3;
 pub const PORT_OFFSET_TO_WEB_SERVER: u16 = 20000;
 // Cache Structures -----------------------------------------------------------
 
@@ -90,7 +89,9 @@ impl DiskCache {
                     debug!("File size: {} bytes", file_size);
                     cache.ensure_capacity(&redis_read, file_size).await;
                     cache.current_size += file_size;
-                    cache.access_order.push_back((uid_str.clone(), file_size.clone()));
+                    cache
+                        .access_order
+                        .push_back((uid_str.clone(), file_size.clone()));
                     let _ = redis_read
                         .set_file_cache_loc(uid_str.clone(), local_file_name.clone())
                         .await;
@@ -122,7 +123,11 @@ impl DiskCache {
             .await
     }
 
-    async fn ensure_capacity(&mut self, redis_read: &RwLockReadGuard<'_, RedisServer>, new_file_size: u64) {
+    async fn ensure_capacity(
+        &mut self,
+        redis_read: &RwLockReadGuard<'_, RedisServer>,
+        new_file_size: u64,
+    ) {
         while self.current_size + new_file_size > self.max_size && !self.access_order.is_empty() {
             if let Some((evicted_file_name, evicted_file_size)) = self.access_order.pop_front() {
                 let evicted_path = self.cache_dir.join(&evicted_file_name);
@@ -131,7 +136,7 @@ impl DiskCache {
                     let _ = redis_read.remove_file(evicted_file_name.clone()).await;
                     info!("Evicted file: {}", evicted_file_name);
                 } else {
-                        eprintln!("Failed to delete file: {}", evicted_path.display());
+                    eprintln!("Failed to delete file: {}", evicted_path.display());
                 }
             }
         }
@@ -148,7 +153,8 @@ impl DiskCache {
             }
         });
         if let Some(size) = file_size {
-            self.access_order.push_back((file_name.to_string(), size.clone()));
+            self.access_order
+                .push_back((file_name.to_string(), size.clone()));
         }
     }
 
@@ -169,14 +175,15 @@ impl ConcurrentDiskCache {
     pub fn new(
         cache_dir: PathBuf,
         max_size: u64,
+        bucket_size: u64,
         redis_addrs: Vec<String>,
         redis_port: u16,
     ) -> Self {
         let _ = std::fs::create_dir_all(cache_dir.clone());
-        let shard_max_size = max_size / BUCKET_SIZE as u64;
+        let shard_max_size = max_size / bucket_size as u64;
         let redis_server = RedisServer::new(redis_addrs).unwrap();
         let redis = Arc::new(RwLock::new(redis_server));
-        let shards = (0..BUCKET_SIZE)
+        let shards = (0..bucket_size)
             .map(|_| DiskCache::new(cache_dir.clone(), shard_max_size))
             .collect::<Vec<_>>();
 
@@ -236,12 +243,16 @@ impl ConcurrentDiskCache {
         for (index, shard) in self.shards.iter().enumerate() {
             match tokio::time::timeout(std::time::Duration::from_secs(5), shard.lock()).await {
                 Ok(shard_guard) => {
-                    let files_in_shard: Vec<_> = shard_guard.access_order.iter()
-                    .map(|(name, size)| format!("{} ({}B)", name, size))
-                    .collect::<Vec<String>>();
+                    let files_in_shard: Vec<_> = shard_guard
+                        .access_order
+                        .iter()
+                        .map(|(name, size)| format!("{} ({}B)", name, size))
+                        .collect::<Vec<String>>();
                     let total_files = files_in_shard.len();
-                    let calculated_current_size: u64 = shard_guard.access_order.iter().map(|(_, size)| size).sum();
-                    let used_capacity_pct = (calculated_current_size as f64 / shard_guard.max_size as f64) * 100.0;
+                    let calculated_current_size: u64 =
+                        shard_guard.access_order.iter().map(|(_, size)| size).sum();
+                    let used_capacity_pct =
+                        (calculated_current_size as f64 / shard_guard.max_size as f64) * 100.0;
                     stats_summary.push_str(&format!(
                         "{:<15} | {:<12} | {:<12.2} | {:<10} | {:?}\n",
                         format!("Shard {}", index),

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -90,8 +90,16 @@ async fn main() -> Result<(), rocket::Error> {
     let region_name = matches.value_of("region").unwrap_or("us-east-1");
     let access_key = matches.value_of("access_key").unwrap_or_default();
     let secret_key = matches.value_of("secret_key").unwrap_or_default();
-    let max_size = matches.value_of("max_size").unwrap().parse::<u64>().unwrap(); // Bytes
-    let bucket_size = matches.value_of("bucket_size").unwrap().parse::<u64>().unwrap();
+    let max_size = matches
+        .value_of("max_size")
+        .unwrap()
+        .parse::<u64>()
+        .unwrap(); // Bytes
+    let bucket_size = matches
+        .value_of("bucket_size")
+        .unwrap()
+        .parse::<u64>()
+        .unwrap();
     let config = if use_mock_s3 {
         ServerConfig {
             redis_port,

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -53,6 +53,8 @@ pub struct ServerConfig {
     pub access_key: Option<String>,
     pub secret_key: Option<String>,
     pub use_mock_s3_endpoint: Option<String>,
+    pub max_size: u64,    // New field for max_size
+    pub bucket_size: u64, // New field for bucket_size
 }
 
 impl ServerNode {
@@ -76,7 +78,8 @@ impl ServerNode {
 
         let cache_manager = Arc::new(ConcurrentDiskCache::new(
             PathBuf::from(&config.cache_dir),
-            6 * 32, // [TODO] make this configurable
+            config.max_size, // [TODO] make this configurable
+            config.bucket_size, // [TODO] make this configurable
             vec![format!("redis://0.0.0.0:{}", config.redis_port)],
             config.redis_port,
         ));

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -53,8 +53,8 @@ pub struct ServerConfig {
     pub access_key: Option<String>,
     pub secret_key: Option<String>,
     pub use_mock_s3_endpoint: Option<String>,
-    pub max_size: u64,    // New field for max_size
-    pub bucket_size: u64, // New field for bucket_size
+    pub max_size: u64,
+    pub bucket_size: u64,
 }
 
 impl ServerNode {
@@ -78,8 +78,8 @@ impl ServerNode {
 
         let cache_manager = Arc::new(ConcurrentDiskCache::new(
             PathBuf::from(&config.cache_dir),
-            config.max_size, // [TODO] make this configurable
-            config.bucket_size, // [TODO] make this configurable
+            config.max_size,
+            config.bucket_size,
             vec![format!("redis://0.0.0.0:{}", config.redis_port)],
             config.redis_port,
         ));

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -76,7 +76,7 @@ impl ServerNode {
 
         let cache_manager = Arc::new(ConcurrentDiskCache::new(
             PathBuf::from(&config.cache_dir),
-            6, // [TODO] make this configurable
+            6 * 32, // [TODO] make this configurable
             vec![format!("redis://0.0.0.0:{}", config.redis_port)],
             config.redis_port,
         ));

--- a/server/src/storage/mock_storage_connector.rs
+++ b/server/src/storage/mock_storage_connector.rs
@@ -22,7 +22,7 @@ impl StorageConnector for MockS3StorageConnector {
         &self,
         file_name: &str,
         cache_path: &PathBuf,
-    ) -> IoResult<PathBuf> {
+    ) -> IoResult<(PathBuf, u64)>  {
         let s3_file_url = format!("{}/{}", self.s3_endpoint, file_name);
         let response = reqwest::get(&s3_file_url)
             .await
@@ -37,15 +37,17 @@ impl StorageConnector for MockS3StorageConnector {
 
         let cache_file_path = cache_path.join(file_name);
         let mut file = File::create(&cache_file_path).await?;
-
+        let mut file_size = 0u64;
         // Stream the response body directly to the file
         let mut stream = response.bytes_stream();
         while let Some(chunk) = stream.next().await {
             let data = chunk.map_err(|e| io_error_from_reqwest(e))?;
+            file_size += data.len() as u64;
             file.write_all(&data).await?;
         }
+        file.flush().await?;
 
-        Ok(Path::new("").join(file_name))
+        Ok((Path::new("").join(file_name), file_size))
     }
 }
 

--- a/server/src/storage/mock_storage_connector.rs
+++ b/server/src/storage/mock_storage_connector.rs
@@ -22,7 +22,7 @@ impl StorageConnector for MockS3StorageConnector {
         &self,
         file_name: &str,
         cache_path: &PathBuf,
-    ) -> IoResult<(PathBuf, u64)>  {
+    ) -> IoResult<(PathBuf, u64)> {
         let s3_file_url = format!("{}/{}", self.s3_endpoint, file_name);
         let response = reqwest::get(&s3_file_url)
             .await

--- a/server/src/storage/s3_storage_connector.rs
+++ b/server/src/storage/s3_storage_connector.rs
@@ -2,6 +2,7 @@ use async_trait::async_trait;
 use aws_sdk_s3::{Client, Config, Credentials, Region};
 use log::debug;
 use rocket::futures::StreamExt;
+use tokio::time::Instant;
 use std::io;
 use std::io::Result as IoResult;
 use std::path::{Path, PathBuf};
@@ -44,14 +45,14 @@ impl StorageConnector for S3StorageConnector {
         &self,
         file_name: &str,
         cache_path: &PathBuf,
-    ) -> IoResult<PathBuf> {
+    ) -> IoResult<(PathBuf, u64)> {
         debug!(
             "Fetching object '{}' from S3 bucket '{}'",
             file_name, self.bucket
         );
         // Assemble the object key with the file name
         let object_key = file_name;
-
+        let start = Instant::now();
         // Attempt to fetch the object from S3
         let result = self
             .client
@@ -66,16 +67,19 @@ impl StorageConnector for S3StorageConnector {
             Ok(resp) => {
                 let cache_file_path = cache_path.join(file_name);
                 let mut file = File::create(&cache_file_path).await?;
-
+                let mut file_size = 0u64;
                 let mut stream = resp.body;
                 while let Some(chunk) = stream.next().await {
                     let data =
                         chunk.map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?;
+                    file_size += data.len() as u64;
                     file.write_all(&data).await?;
                 }
+                file.flush().await?;
+                let duration = start.elapsed();
 
-                debug!("Object '{}' fetched successfully", file_name);
-                Ok(Path::new("").join(file_name))
+                debug!("Object '{}' fetched and cached successfully with size: {} bytes in {:?}", file_name, file_size, duration);
+                Ok((Path::new("").join(file_name), file_size))
             }
             Err(aws_sdk_s3::SdkError::ServiceError { err, .. }) => {
                 match err.kind {

--- a/server/src/storage/s3_storage_connector.rs
+++ b/server/src/storage/s3_storage_connector.rs
@@ -2,12 +2,12 @@ use async_trait::async_trait;
 use aws_sdk_s3::{Client, Config, Credentials, Region};
 use log::debug;
 use rocket::futures::StreamExt;
-use tokio::time::Instant;
 use std::io;
 use std::io::Result as IoResult;
 use std::path::{Path, PathBuf};
 use tokio::fs::File;
 use tokio::io::AsyncWriteExt;
+use tokio::time::Instant;
 
 use super::storage_connector::StorageConnector;
 
@@ -78,7 +78,10 @@ impl StorageConnector for S3StorageConnector {
                 file.flush().await?;
                 let duration = start.elapsed();
 
-                debug!("Object '{}' fetched and cached successfully with size: {} bytes in {:?}", file_name, file_size, duration);
+                debug!(
+                    "Object '{}' fetched and cached successfully with size: {} bytes in {:?}",
+                    file_name, file_size, duration
+                );
                 Ok((Path::new("").join(file_name), file_size))
             }
             Err(aws_sdk_s3::SdkError::ServiceError { err, .. }) => {

--- a/server/src/storage/storage_connector.rs
+++ b/server/src/storage/storage_connector.rs
@@ -9,5 +9,5 @@ pub trait StorageConnector {
         &self,
         file_name: &str,
         cache_path: &PathBuf,
-    ) -> IoResult<PathBuf>;
+    ) -> IoResult<(PathBuf, u64)> ;
 }

--- a/server/src/storage/storage_connector.rs
+++ b/server/src/storage/storage_connector.rs
@@ -9,5 +9,5 @@ pub trait StorageConnector {
         &self,
         file_name: &str,
         cache_path: &PathBuf,
-    ) -> IoResult<(PathBuf, u64)> ;
+    ) -> IoResult<(PathBuf, u64)>;
 }

--- a/server/tests/test_integration.rs
+++ b/server/tests/test_integration.rs
@@ -80,7 +80,7 @@ fn test_evict() {
 #[test]
 fn test_s3_connector() {
     let (_, [client_1, _, _]) = utils::launch_server_node_size_3(false);
-    let response = client_1.get("/s3/test2.txt").dispatch();
+    let response: rocket::local::blocking::LocalResponse = client_1.get("/s3/test2.txt").dispatch();
     assert_eq!(response.status(), Status::Ok);
     let response = client_1.post("/clear").dispatch();
     assert_eq!(response.status(), Status::Ok);

--- a/server/tests/utils.rs
+++ b/server/tests/utils.rs
@@ -11,6 +11,8 @@ pub fn get_server_config_mocks3(redis_port: u16) -> ServerConfig {
         region_name: None,
         access_key: None,
         secret_key: None,
+        max_size: 192,
+        bucket_size: 3,
     }
 }
 
@@ -27,6 +29,8 @@ pub fn get_server_config_s3(
         region_name: Some("us-east-1".into()),
         access_key: Some(aws_access_key),
         secret_key: Some(aws_secret_key),
+        max_size: 192,
+        bucket_size: 3,
     }
 }
 


### PR DESCRIPTION
This PR introduces a significant overhaul of our caching mechanism by shifting to a real file-size-based Least Recently Used (LRU) strategy. Additionally, it adds two new configurable parameters to enhance control over the cache behavior and efficiency:

max_size: This update adds a new command-line argument --max-size that allows configuration of the cache's maximum capacity in bytes. This parameter is crucial for managing memory utilization based on the available system resources.
bucket_size: A new command-line argument --bucket-size has been introduced, enabling the specification of the bucket size for the cache. This parameter influences the granularity of cache management and can impact performance, particularly in environments with high transaction rates.